### PR TITLE
Update connection string to trust server certificate

### DIFF
--- a/CsvDataLayer/App.config
+++ b/CsvDataLayer/App.config
@@ -2,7 +2,7 @@
 <configuration>
   <connectionStrings>
     <add name="CsvImporter" 
-         connectionString="data source=localhost;initial catalog=CsvImporter;persist security info=True;Integrated Security=SSPI;"
+         connectionString="data source=localhost;initial catalog=CsvImporter;persist security info=True;Integrated Security=SSPI;TrustServerCertificate=True;"
          providerName="System.Data.SqlClient" />
   </connectionStrings>
 </configuration>

--- a/CsvImporter/App.config
+++ b/CsvImporter/App.config
@@ -2,7 +2,7 @@
 <configuration>
   <connectionStrings>
     <add name="CsvImporter" 
-         connectionString="data source=localhost;initial catalog=CsvImporter;persist security info=True;Integrated Security=SSPI;"
+         connectionString="data source=localhost;initial catalog=CsvImporter;persist security info=True;Integrated Security=SSPI;TrustServerCertificate=True;"
          providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>


### PR DESCRIPTION
The connection string for the `CsvImporter` database in the `App.config` file has been updated to include the `TrustServerCertificate=True;` parameter. This change ensures that the SQL Server will trust the server certificate without performing validation, which can be useful in certain scenarios where certificate validation is not necessary or desired.